### PR TITLE
Add FreeBSD support

### DIFF
--- a/lib/facter/diskspace.rb
+++ b/lib/facter/diskspace.rb
@@ -1,10 +1,10 @@
 require 'facter'
 
-$supported_os = [ 'Linux', 'AIX', 'Darwin',  'windows' ]
+$supported_os = [ 'Linux', 'AIX', 'FreeBSD', 'Darwin',  'windows' ]
 kernel = Facter.value(:kernel)
 
 case kernel
-when 'Linux','AIX'
+when 'Linux','AIX','FreeBSD'
   df      = '/bin/df -P'
   pattern = '^(?:map )?([/\w\-\.:\-]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+([/\w\-\.:]+)'
   dmatch  = 6

--- a/metadata.json
+++ b/metadata.json
@@ -45,6 +45,14 @@
         "6.1",
         "7.1"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
+      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
This adds support for FreeBSD systems.  It shares the 'df' path
and patterns with Linux/AIX.  Also update the module's metadata.
