### PR TITLE
Corrected Darwin dmatch from 9 to 6

### DIFF
--- a/lib/facter/diskspace.rb
+++ b/lib/facter/diskspace.rb
@@ -12,7 +12,7 @@ when 'Linux','AIX'
 when 'Darwin'
   df      = '/usr/bin/df -P'
   pattern = '^(?:map )?([/\w\-\.:\-]+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)%\s+([/\w\-\.:]+)'
-  dmatch  = 9
+  dmatch  = 6
   umatch  = 5
 when 'windows'
   df      = 'C:\Windows\System32\wbem\WMIC.exe logicaldisk get deviceid,freespace,size'


### PR DESCRIPTION
Correction for kernel=Darwin as there are only 6 matches in the pattern, and 6 also matches where the device is in the sample output below we see from df -P on a few Darwin hosts.

```
    #  [andywash:~]$ df -P
    #  Filesystem    512-blocks      Used Available Capacity  Mounted on
    #  /dev/disk1     974716928 151397136 822807792    16%    /
    #  devfs                370       370         0   100%    /dev
    #  map -hosts             0         0         0   100%    /net
    #  map auto_home          0         0         0   100%    /home
```
