### PR TITLE
Add Solaris support, add fact for freespace in kb and updated metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,31 @@ Filesystems entitled ```/``` will be listed as ```root``` instead.
 ###*nix style systems
 ```
 # facter -p | grep diskspace
-diskspace_boot => 31
+diskspace_boot => 15
 diskspace_devshm => 0
-diskspace_root => 54
-diskspacefree_boot => 69
+diskspace_home => 20
+diskspace_root => 25
+diskspace_var => 14
+diskspacefree_boot => 85
 diskspacefree_devshm => 100
-diskspacefree_root => 46
+diskspacefree_home => 80
+diskspacefree_root => 75
+diskspacefree_var => 86
+diskspacefreekb_boot => 401675
+diskspacefreekb_devshm => 961780
+diskspacefreekb_home => 1568664
+diskspacefreekb_root => 5206584
+diskspacefreekb_var => 3407840
 ```
 
 ###Windows systems
 ```
 C:\>facter -p | find "diskspace"
-diskspace_c => 31
-diskspacefree_c => 69
+diskspace_c => 17
+diskspacefree_c => 83
+diskspacefreekb_c => 69533888
 ```
+
+
+
+

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,7 @@
   "source": "https://github.com/WhatsARanjit/puppet-diskspace",
   "project_page": "https://github.com/WhatsARanjit/puppet-diskspace",
   "issues_url": "https://github.com/WhatsARanjit/puppet-diskspace/issues",
+  "tags": ["disk", "space", "facter", "facts"],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
@@ -52,6 +53,19 @@
         "8",
         "9",
         "10"
+      ]
+    },
+    {
+      "operatingsystem":"Windows"
+    },
+    {
+      "operatingsystem":"Solaris"
+    },
+    {
+      "operatingsystem":"OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "author": "WhatsARanjit",
   "summary": "Facts for diskspace used and free",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/WhatsARanjit/puppet-diskspace",
   "project_page": "https://github.com/WhatsARanjit/puppet-diskspace",
   "issues_url": "https://github.com/WhatsARanjit/puppet-diskspace/issues",
@@ -60,6 +60,9 @@
     },
     {
       "operatingsystem":"Solaris"
+    },
+    {
+      "operatingsystem":"Darwin"
     },
     {
       "operatingsystem":"OracleLinux",


### PR DESCRIPTION
Tested on Darwin, Windows 2008 & 2012, Oracle Linux 6 and 7, and Solaris x86 2.10.
